### PR TITLE
feature: upgrade flutter_math_fork to 0.6.3 version for flutter 3.X compatible

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   flutter_svg: '>=0.22.0 <2.0.0'
 
   # Plugin for rendering MathML
-  flutter_math_fork: '>=0.4.2+1 <1.0.0'
+  flutter_math_fork: '>=0.6.3+1 <1.0.0'
 
   # plugin for firstWhereOrNull extension on lists
   collection: '>=1.15.0 <2.0.0'


### PR DESCRIPTION
Upgrade flutter_math_fork package to latest version in order to deal with the null check operator issue in the WidgetsBinding. and SchedulerBinding. with the upgrade of flutter to version >3.X